### PR TITLE
avoid closing connection after request

### DIFF
--- a/wazo_lib_rest_client/client.py
+++ b/wazo_lib_rest_client/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 import logging
@@ -91,7 +91,6 @@ class BaseClient(object):
 
     def session(self):
         session = Session()
-        session.headers = {'Connection': 'close'}
 
         if self.timeout is not None:
             session.request = partial(session.request, timeout=self.timeout)


### PR DESCRIPTION
reason: this limitation was to avoid to take all workers from service
(cheroot default to 10) by keeping session opened. But now, all service
communicate with plain HTTP and the SSL is handled by nginx