### PR TITLE
cast tenant_uuid to string

### DIFF
--- a/wazo_lib_rest_client/command.py
+++ b/wazo_lib_rest_client/command.py
@@ -45,5 +45,5 @@ class RESTCommand(HTTPCommand):
         # The requests session will use self.tenant_uuid by default
         tenant_uuid = kwargs.pop('tenant_uuid', None)
         if tenant_uuid:
-            headers['Wazo-Tenant'] = tenant_uuid
+            headers['Wazo-Tenant'] = str(tenant_uuid)
         return headers


### PR DESCRIPTION
why: to be able to use python UUID without needed to convert to str
before