### PR TITLE
bump stevedore dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 REQUIREMENTS = [
     'requests==2.25.1',
-    'stevedore==3.2.2',
+    'stevedore==4.0.2',
 ]
 
 setup(


### PR DESCRIPTION
why: to avoid incompatibility with stevedore and setuptools
stevedore==3.2.2 is incompatible with setuptools>=71.0.0

see WAZO-3891 for details