### PR TITLE
setup.py: relax requests version specifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 from setuptools import find_packages, setup
 
 REQUIREMENTS = [
-    'requests==2.25.1',
+    'requests>=2.25.1',
     'stevedore==4.0.2',
 ]
 


### PR DESCRIPTION
why: general good practice, enable using other libraries depending on other requests version

(assume forward compatibility for pip installs, until compatibility breaks is detected)
